### PR TITLE
Fix for MongoDB Compatibility Issue

### DIFF
--- a/giftlink-backend/package.json
+++ b/giftlink-backend/package.json
@@ -18,7 +18,7 @@
     "express": "^4.18.2",
     "express-validator": "^7.0.1",
     "jsonwebtoken": "^9.0.2",
-    "mongodb": "^6.3.0",
+    "mongodb": "6.8.0",
     "pino": "^8.17.2",
     "pino-http": "^9.0.0",
     "pino-pretty": "^10.3.1"

--- a/giftlink-backend/util/import-mongo/package.json
+++ b/giftlink-backend/util/import-mongo/package.json
@@ -12,6 +12,6 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.3.1",
-    "mongodb": "^6.3.0"
+    "mongodb": "6.8.0"
   }
 }


### PR DESCRIPTION
When running the Node.js server, the following error occurs:
MongoServerSelectionError: Server at 172.21.201.54:27017 reports maximum wire version 6, but this version of the Node.js Driver requires at least 7 (MongoDB 4.0).
This error is caused by an incompatibility between the lab's MongoDB server version (3.6) and the MongoDB Node.js driver, which requires MongoDB 4.0 or higher.
To resolve the issue , the MongoDB driver is downgraded to version 6.8 in package.json, ensuring compatibility with MongoDB 3.6.